### PR TITLE
Add Deployment and DeploymentHistory to Data Model

### DIFF
--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -96,6 +96,7 @@ Contracts, Constructors, and Instances
   scale 0.75
 
   !define SHOW_CONTRACT
+  !define SHOW_DEPLOYMENT_HISTORY
   !define SHOW_DEPLOYMENT
   !define SHOW_INSTANCE
   !define SHOW_CONSTRUCTOR
@@ -182,6 +183,7 @@ Combined Data Model
 
    !define SHOW_CONTRACT
    !define SHOW_INTERFACE
+   !define SHOW_DEPLOYMENT_HISTORY
    !define SHOW_DEPLOYMENT
    !define SHOW_INSTANCE
    !define SHOW_ABI

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -96,6 +96,7 @@ Contracts, Constructors, and Instances
   scale 0.75
 
   !define SHOW_CONTRACT
+  !define SHOW_DEPLOYMENT
   !define SHOW_INSTANCE
   !define SHOW_CONSTRUCTOR
   !define SHOW_INTERFACE
@@ -181,6 +182,7 @@ Combined Data Model
 
    !define SHOW_CONTRACT
    !define SHOW_INTERFACE
+   !define SHOW_DEPLOYMENT
    !define SHOW_INSTANCE
    !define SHOW_ABI
    !define SHOW_AST

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -42,13 +42,31 @@ skinparam defaultMonospacedFontName Andale Mono
   !endif
 !endif
 
-!define SHOW_DEPLOYMENT
+!ifdef SHOW_DEPLOYMENT_HISTORY
+  !define SHOW_DEPLOYMENT
+
+  resource(DeploymentHistory) {
+    + <u>current</u> (\n\ttype: String,\n\tname: String,\n\trole: Maybe<Object>\n):\n\tMaybe<DeploymentHistory>
+    --
+    + type: String
+    + name: String
+    + role: Maybe<Object>
+    + {method} ref: Deployment
+    + previous: Maybe<DeploymentHistory>
+    ..
+    UNKNOWN_ID
+  }
+
+  DeploymentHistory o-- "1" Deployment
+  DeploymentHistory o-- "0..1" DeploymentHistory
+!endif
 
 !ifdef SHOW_DEPLOYMENT
   !define SHOW_INSTANCE
 
   resource(Deployment) {
-    + network: Network
+    + name: String
+    + role: Maybe<Object>
     + contractInstances: Array<ContractInstance>
     ..
     UNKNOWN_ID

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -42,6 +42,21 @@ skinparam defaultMonospacedFontName Andale Mono
   !endif
 !endif
 
+!define SHOW_DEPLOYMENT
+
+!ifdef SHOW_DEPLOYMENT
+  !define SHOW_INSTANCE
+
+  resource(Deployment) {
+    + network: Network
+    + contractInstances: Array<ContractInstance>
+    ..
+    UNKNOWN_ID
+  }
+
+  ContractInstance "1..n" ---o Deployment
+!endif
+
 !ifdef SHOW_INSTANCE
   !define SHOW_INSTANCE_CREATION
   !define SHOW_LINKED_BYTECODE


### PR DESCRIPTION
This PR adds the named `Deployment` resource

It also adds a `DeploymentHistory` resource which temporarily adds a `Name<T>` (see https://trufflesuite.github.io/artifact-updates/data-model.html#name-referenced-resources) for `Deployment`