### PR TITLE
Add network genealogy and network relationship; remove network fork

### DIFF
--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -73,6 +73,8 @@ Contracts, Constructors, and Instances
   !define SHOW_NETWORK
   !define EXTERN_NETWORK
 
+  !define SHOW_NETWORK_GENEALOGY
+
   !include uml/macros.iuml
 
 Sources, Bytecodes, and Compilations
@@ -117,15 +119,14 @@ Network
 
   !define SHOW_NETWORK
   !define SHOW_NETWORK_INTERNAL
+  !define SHOW_NETWORK_GENEALOGY
 
   !include uml/macros.iuml
 
 
-A network resource comprises a friendly name, a network ID, a known historic
-block, and possibly an originating fork.
+A network resource comprises a friendly name, a network ID, and a known historic
+block.
 
-Networks that specify a ``fork`` value must specify a ``historicBlock`` whose
-``height`` is larger than the fork network's historic block height.
 
 Combined Data Model
 -------------------
@@ -138,6 +139,7 @@ Combined Data Model
    !define SHOW_NAME_RECORD
    !define SHOW_NETWORK
    !define SHOW_NETWORK_INTERNAL
+   !define SHOW_NETWORK_GENEALOGY
 
    !define SHOW_BYTECODE
 

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -73,8 +73,6 @@ Contracts, Constructors, and Instances
   !define SHOW_NETWORK
   !define EXTERN_NETWORK
 
-  !define SHOW_NETWORK_GENEALOGY
-
   !include uml/macros.iuml
 
 Sources, Bytecodes, and Compilations
@@ -119,7 +117,6 @@ Network
 
   !define SHOW_NETWORK
   !define SHOW_NETWORK_INTERNAL
-  !define SHOW_NETWORK_GENEALOGY
 
   !include uml/macros.iuml
 
@@ -139,7 +136,6 @@ Combined Data Model
    !define SHOW_NAME_RECORD
    !define SHOW_NETWORK
    !define SHOW_NETWORK_INTERNAL
-   !define SHOW_NETWORK_GENEALOGY
 
    !define SHOW_BYTECODE
 

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -285,7 +285,6 @@ skinparam defaultMonospacedFontName Andale Mono
       + name : String
       + networkId : NetworkID
       + historicBlock: Block
-      + {method} fork: Maybe<Network>
       ..
     }
   !else
@@ -293,10 +292,8 @@ skinparam defaultMonospacedFontName Andale Mono
       + name : String
       + networkId : NetworkID
       + historicBlock: Block
-      + {method} fork: Maybe<Network>
       ..
       hashIdField(networkId,historicBlock)
-      - forkId: Maybe<ID>
     }
   !endif
 
@@ -312,7 +309,16 @@ skinparam defaultMonospacedFontName Andale Mono
     !endif
 !endif
 
+!ifdef SHOW_NETWORK_GENEALOGY
+    resource(NetworkGenealogy) {
+      + ancestor: Network
+      + descendant: Network
+      ..
+      hashIdField(ancestor, descendant)
+    }
 
+    Network  "2" ---o  NetworkGenealogy
+!endif
 
 '
 ' Shared Data Objects

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -317,7 +317,7 @@ skinparam defaultMonospacedFontName Andale Mono
       hashIdField(ancestor, descendant)
     }
 
-    Network  "2" ---o  NetworkGenealogy
+    NetworkGenealogy o-- "2" Network
 !endif
 
 '
@@ -527,4 +527,3 @@ skinparam defaultMonospacedFontName Andale Mono
 !ifdef SHOW_SOURCE_RANGE && SHOW_SOURCE
   Source "1" --o SourceRange
 !endif
-

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -311,7 +311,7 @@ skinparam defaultMonospacedFontName Andale Mono
         hashIdField(ancestor, descendant)
       }
 
-      Network  "2" ---o  NetworkGenealogy
+      NetworkGenealogy o--  "2" Network
       Network o-- "0..1" Network : <<refines>>
       Network *-- "1" Block
     !endif

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -304,20 +304,17 @@ skinparam defaultMonospacedFontName Andale Mono
         + hash : BlockHash
       }
 
+      resource(NetworkGenealogy) {
+        + ancestor: Network
+        + descendant: Network
+        ..
+        hashIdField(ancestor, descendant)
+      }
+
+      Network  "2" ---o  NetworkGenealogy
       Network o-- "0..1" Network : <<refines>>
       Network *-- "1" Block
     !endif
-!endif
-
-!ifdef SHOW_NETWORK_GENEALOGY
-    resource(NetworkGenealogy) {
-      + ancestor: Network
-      + descendant: Network
-      ..
-      hashIdField(ancestor, descendant)
-    }
-
-    Network  "2" ---o  NetworkGenealogy
 !endif
 
 '


### PR DESCRIPTION
This PR adds the `NetworkGenealogy` resource to the data model, and removes fork from the network resource.

[Preview](https://trufflesuite.github.io/artifact-updates/contrib/trufflesuite/add-network-genealogy)